### PR TITLE
automate rebasing from original repo

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,42 @@
+name: Rebase from Upstream
+
+# https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#scheduled-events
+on:
+  schedule: # run every monday at 5:03 AM UTC
+    - cron: "3 5 * * 1"  # https://crontab.guru/#3_5_*_*_1
+
+jobs:
+  rebase_from_upstream:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: "[checkout] Checkout Code"
+      uses: actions/checkout@v2
+    - name: "fetch upstream"
+      run: |
+        git fetch upstream
+    - name: "determine and set the BRANCH_NAME"
+      run: |
+        echo "BRANCH_NAME="automated-updates/`date "+%Y-%m-%d"` >> $GITHUB_ENV
+    - name: "checkout new branch"
+      run: |
+        echo "Creating a new branch:"${{ env.BRANCH_NAME }}
+        git checkout -b ${{ env.BRANCH_NAME }}
+    - name: "rebase off of upstream"
+      run: |
+        git rebase upstream
+        # TODO: determine wether or not there are any changes so as to not create unnecessary/emtpy PRs.
+    - name: "push this new branch"
+      run: |
+        git push origin
+    - name: "create pull request"
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ env.BRANCH_NAME }}
+        commit-message: "Bringing in latest changes from upstream."
+        labels: |
+          automated
+    - name: "tag admins in PR"
+      run: |
+        echo "TODO"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,78 @@ scratch/
 # do include Installomator .pkg files
 #!Installomator-*.pkg
 checkLabelCurrent.sh
+
+
+# Created by https://www.toptal.com/developers/gitignore/api/osx,vim,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=osx,vim,visualstudiocode
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+!.vscode/*.code-snippets
+
+# End of https://www.toptal.com/developers/gitignore/api/osx,vim,visualstudiocode

--- a/ABOUT.md
+++ b/ABOUT.md
@@ -1,0 +1,46 @@
+# About this fork
+
+## What is it?
+
+## Updates
+
+We want to keep this up to date with the upstream. To achieve that, we will
+
+1. check out the latest version of the upstream
+2. rebase our work off of the latest
+3. open a pull request with these changes and tag @mattdjerome and @frisson
+4. ec tech will review, update, approve, and merge changes as appropriate.
+
+This process will be automated using github actions and set to run on a
+schedule. See [`.github/workflows/update.yml`](.github/workflows/update.yml) for
+implementation details.
+
+#### Summary
+
+From an up to date master branch, run the following.
+
+Get the latest version of our clone and get the latest from the upstream.
+
+```bash
+git checkout master     # our master
+git pull origin master  # get the latest changes
+git fetch upstream --all --prune  # get the latest from the upstream
+```
+
+Create a new branch with our latest changes from master and rebase this branch
+off of the upstream.
+
+```bash
+git checkout -b automated-updates/`date "+%Y-%m-%d"`  # create a new branch
+git rebase upstream/master
+git push
+```
+
+In github or via the cli (`hub`), create a new pull request.
+
+### Details
+
+| Repo                | URL                                                | Description             |
+| ------------------- | -------------------------------------------------- | ----------------------- |
+| Upstream (original) | https://github.com/Installomator/Installomator     | Original Repo we forked |
+| This Repo           | https://github.com/emersoncollective/Installomator | The repo we modify      |

--- a/ABOUT.md
+++ b/ABOUT.md
@@ -6,8 +6,8 @@
 
 We want to keep this up to date with the upstream. To achieve that, we will
 
-1. check out the latest version of the upstream
-2. rebase our work off of the latest
+1. fetch the latest version of the upstream's master
+2. rebase our work off of the upstream's master
 3. open a pull request with these changes and tag @mattdjerome and @frisson
 4. ec tech will review, update, approve, and merge changes as appropriate.
 
@@ -44,3 +44,7 @@ In github or via the cli (`hub`), create a new pull request.
 | ------------------- | -------------------------------------------------- | ----------------------- |
 | Upstream (original) | https://github.com/Installomator/Installomator     | Original Repo we forked |
 | This Repo           | https://github.com/emersoncollective/Installomator | The repo we modify      |
+
+## Sources
+
+1. https://gist.github.com/ravibhure/a7e0918ff4937c9ea1c456698dcd58aa


### PR DESCRIPTION
### Description

We want to keep a custom version of [Installomator](https://github.com/Installomator/Installomator) with our changes. However, we also want to have the option to bring in changes to the source/`upstream`. 

We want to automate the process of pulling in changes to the `upstream`'s master. 

#### How is this done

In a github action

1. fetch the upstream
2. make a new branch from our clone's master
3. rebase this branch off the upstream
4. open a pull request for this updated branch
5. tag whomstever

### Test/QA Plan

Merge a PR with the action and trigger the action manually. 


### Notes

1. We may consider not making a PR if there are no changes to the master. 
2. We may want to notify members of EC's org when a new PR is made via comments or some other means. 
