### PR TITLE
actions/update: fix broken yaml from dirty merge

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,7 +15,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref:  master
-<<<<<<< HEAD
         persist-credentials: false
     - name: "[git] determine and set the BRANCH_NAME"
       run: |
@@ -34,35 +33,6 @@ jobs:
         upstream_sync_repo: Installomator/Installomator
         upstream_repo_access_token: ${{ secrets.UPSTREAM_REPO_SECRET }}
     - name: "create pull request"
-=======
-    - name: "[git] determine and set the BRANCH_NAME"
-      run: |
-        echo "BRANCH_NAME="automated-updates/`date "+%Y-%m-%d"` >> $GITHUB_ENV
-    - name: "Sync upstream changes"
-      id: sync
-      uses: aormsby/Fork-Sync-With-Upstream-action@check-fix-2  # using branch
-      with:
-        target_sync_branch: master
-        target_repo_token: ${{ secrets.GITHUB_TOKEN }}
-        upstream_sync_branch: master
-        upstream_sync_repo: Installomator/Installomator
-        # test_mode: true
-    - name: "Show value of 'has_new_commits'"
-      run: |
-        echo "Showing output from sync step"
-        echo ${{ steps.sync.outputs.has_new_commits }}
-        echo
-        echo echo ${{ steps.sync.outputs }}
-    - name: "[git] create a new branch"
-      if: steps.sync.outputs.has_new_commits == 'true'
-      uses: peterjgrainger/action-create-branch@v2.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        branch: ${{ env.BRANCH_NAME }}
-    - name: "create pull request"
-      if: steps.sync.outputs.has_new_commits == 'true'
->>>>>>> 965dbe73451c3bd87b9783fed3ed7c9170b4038e
       uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -73,8 +43,5 @@ jobs:
     - name: "No new commits"
       if: steps.sync.outputs.has_new_commits == 'false'
       run: echo "There were no new commits."
-<<<<<<< HEAD
     - name: "Show value of 'has_new_commits'"
       run: echo ${{ steps.sync.outputs.has_new_commits }}
-=======
->>>>>>> 965dbe73451c3bd87b9783fed3ed7c9170b4038e


### PR DESCRIPTION
### Description

The update action yaml definition had what looked like a merge conflict committed to it. See lines with `HEAD` and `<<<` in them. 

This removes those changes. 